### PR TITLE
requirements: force the version of certifi to >= current latest

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ strict-rfc3339
 rfc3987
 rfc6266
 requests[socks]
+certifi>=2020.12.05

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,10 @@ backports-datetime-fromisoformat==1.0.0
     # via flattentool
 btrees==4.7.2
     # via zodb
-certifi==2020.6.20
-    # via requests
+certifi==2020.12.5
+    # via
+    #   -r requirements.in
+    #   requests
 cffi==1.14.5
     # via persistent
 chardet==3.0.4


### PR DESCRIPTION
requests it's self only requires 'certifi>=2017.4.17' so we need a way
to push the requirement higher otherwise we seem to only select
2020.6.20.