### PR TITLE
get: If unflatten fails mark data as invalid

### DIFF
--- a/getter/get.py
+++ b/getter/get.py
@@ -187,10 +187,12 @@ def fetch_and_convert(args, dataset):
                     file_type)
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception:
                 print("\n\nUnflattening failed for file {}\n".format(file_name))
                 traceback.print_exc()
                 metadata['json'] = None
+                metadata["valid"] = False
+                metadata["error"] = "Could not unflatten file"
             else:
                 metadata['json'] = json_file_name
 


### PR DESCRIPTION
Sometimes we get silly files back from the webserver such as custom
error pages instead of the documents. This can also happen if the file downloads
but is incomplete or broken in some other way but also downloaded
without an erroneous HTTP code.

Related to #20 