### PR TITLE
schema: Cache the schema in the filesytem for reduced requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 .ve/
+data

--- a/getter/get.py
+++ b/getter/get.py
@@ -231,9 +231,17 @@ def fetch_and_convert(args, dataset, schema_path):
 def file_cache_schema():
     tmp_dir = tempfile.mkdtemp()
     schema_path = os.path.join(tmp_dir, '360-giving-schema.json')
-    schema = requests.get('https://raw.githubusercontent.com/ThreeSixtyGiving/standard/master/schema/360-giving-schema.json')
+    try: 
+        print("\nDownloading 360Giving Schema...\n")
+        schema = requests.get('https://raw.githubusercontent.com/ThreeSixtyGiving/standard/master/schema/360-giving-schema.json')
+    except Exception as e:
+        print("Download failed for 360Giving Schema\n")
+        traceback.print_exc()
+
     with open(schema_path, 'w') as fp:
         fp.write(schema.text)
+
+    print("Schema Download successful.\n")
     return schema_path
 
 


### PR DESCRIPTION
I looked at caching the schema in memory rather than the filesystem, but it looks like there is currently no way to pass this to flatten tool.

Closes #10 