### PR TITLE
get: Use the main multiprocessing pool for multiprocess vs multithreads

### DIFF
--- a/getter/get.py
+++ b/getter/get.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 import traceback
-from multiprocessing.dummy import Pool
+from multiprocessing import Pool
 
 import flattentool
 import requests


### PR DESCRIPTION
Due to the fact we have no problem with concurrency of data access we
can easily convert this process to use multiprocessing rather than multi
threaded.