### PR TITLE
get: Add new argument to specify particular publishers to download

### DIFF
--- a/datagetter.py
+++ b/datagetter.py
@@ -34,6 +34,9 @@ def main():
                         help="Specify a git branch of the 360Giving schema",
                         default='master')
 
+    parser.add_argument("--publishers", nargs="+", dest="publisher_prefixes", action="store",
+                        type=str, help="Only download for selected publishers")
+
     args = parser.parse_args()
 
     get(args)

--- a/getter/get.py
+++ b/getter/get.py
@@ -97,6 +97,12 @@ def mkdirs(data_dir, exist_ok=False):
 
 
 def fetch_and_convert(args, dataset, schema_path, package_schema):
+    # must always return dataset
+
+    if args.publisher_prefixes:
+        if dataset["publisher"]["prefix"] not in args.publisher_prefixes:
+            return dataset
+
     try:
         r = None
 
@@ -325,9 +331,12 @@ def get(args):
         print("No source for data")
         exit(1)
 
-
     if args.limit_downloads:
         data_all = data_all[:args.limit_downloads]
+        if args.publisher_prefixes:
+            print("Warning: Limit applied and publisher prefixes selected, can have one or the other not both.")
+            exit(1)
+
 
     schema_path = file_cache_schema(args.schema_branch)
     package_schema = json.loads(requests.get(f"https://raw.githubusercontent.com/ThreeSixtyGiving/standard/{args.schema_branch}/schema/360-giving-package-schema.json").text)


### PR DESCRIPTION
--publishers allows one to select publishers to download that are available in the registry

This is especially useful for loading specific publisher data into the dev datastore for testing purposes.