### PR TITLE
README: Make Readme more useful by adding current options to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,38 @@ $ setup.py install
 
 ## Usage
 
-Run:
+Basic usage to download all published 360Giving data run:
+
 ```
-# See datagetter.py --help for options
 $ datagetter.py
+```
+
+### See datagetter.py --help for more options
+
+```
+
+$ datagetter.py --help
+usage: datagetter.py [-h] [--no-download] [--local-registry LOCAL_REGISTRY] [--no-convert] [--no-convert-big-files] [--no-validate] [--data-dir DATA_DIR] [--threads THREADS] [--socks5 SOCKS5_PROXY] [--limit-downloads LIMIT_DOWNLOADS] [--schema-branch SCHEMA_BRANCH]
+                     [--publishers PUBLISHER_PREFIXES [PUBLISHER_PREFIXES ...]]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --no-download         Don't download any files only convert existing data
+  --local-registry LOCAL_REGISTRY
+                        Use a local registry file rather than data.threesixtygiving.org
+  --no-convert
+  --no-convert-big-files
+  --no-validate
+  --data-dir DATA_DIR
+  --threads THREADS
+  --socks5 SOCKS5_PROXY
+                        Use a socks5 proxy to fetch publisher data. Example --socks5=socks5://host:port
+  --limit-downloads LIMIT_DOWNLOADS
+                        Limit the number of file downloads
+  --schema-branch SCHEMA_BRANCH
+                        Specify a git branch of the 360Giving schema
+  --publishers PUBLISHER_PREFIXES [PUBLISHER_PREFIXES ...]
+                        Only download for selected publishers
 ```
 
 ## Developers


### PR DESCRIPTION
This gives a better indication as to what the datagetter can do before it's checked out or as a quick reference when a copy of it isn't to-hand.