### PR TITLE
requirements: Unpin very old importlib-metadata

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,4 @@ requests[socks]
 
 # Compatibility with CoVE
 attrs>=20.3.0
-importlib-metadata==1.7.0
 openpyxl==2.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,6 @@ idna==3.3
     # via requests
 ijson==3.1.4
     # via flattentool
-importlib-metadata==1.7.0
-    # via -r requirements.in
 jdcal==1.4.1
     # via openpyxl
 jsonref==0.2
@@ -82,8 +80,6 @@ zc-zlibstorage==1.2.0
     # via flattentool
 zconfig==3.6.0
     # via zodb
-zipp==3.6.0
-    # via importlib-metadata
 zodb==5.6.0
     # via
     #   flattentool


### PR DESCRIPTION
It's unclear that importlib-metadata needs to be pinned in `requirements.in`, as it's a core package we don't use directly. This pin of a very old version is causing issues with trying to use newer versions of libraries in TSG/datastore.

It appears that no other ODSC or TSG project pins this package in their `requirements.in` files, so I think this unpin should be safe.

From searching in the projects:
https://github.com/search?q=org%3AThreeSixtyGiving+importlib-metadata&type=code
https://github.com/search?q=org%3AOpenDataServices+importlib-metadata&type=code