### PR TITLE
datagetter.py: changed default branch of schema

### DIFF
--- a/datagetter.py
+++ b/datagetter.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument('--schema-branch', dest='schema_branch', action='store',
                         type=str,
                         help="Specify a git branch of the 360Giving schema",
-                        default='master')
+                        default='main')
 
     parser.add_argument("--publishers", nargs="+", dest="publisher_prefixes", action="store",
                         type=str, help="Only download for selected publishers")


### PR DESCRIPTION
Changed the default branch of the schema in datagetter.py to 'main' from
'master' to reflect upcoming change in the schema repo
