### PR TITLE
Loosen the requirements when the datagetter is used as a library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 install_requires = []
 
-with open('./requirements.txt') as requirements_txt:
+with open('./requirements.in') as requirements_txt:
     requirements = requirements_txt.read().strip().splitlines()
     for requirement in requirements:
         if requirement.startswith('#'):


### PR DESCRIPTION
by switching setup.py to use requirements.in instead of requirements.txt.

Now that requirements.in specifies compatible ranges, this allows downstream library uses to upgrade to compatible sub-requirement versions, e.g. for security updates, without needing to first update the requirements.txt in this repo.