### PR TITLE
get: Remove incorrectly commented code that in python-black commit

### DIFF
--- a/getter/get.py
+++ b/getter/get.py
@@ -310,7 +310,7 @@ def fetch_and_convert(args, dataset, schema_path, schema_package_path):
                         f"Warning: File {json_file_name} does not conform to 360Giving standard"
                     )
                     # Non-standard data breaks tools so get rid of it
-                    #                    metadata['json'] = None
+                    metadata["json"] = None
                     metadata["valid"] = False
                     metadata["error"] = (
                         "File does not conform to the 360Giving standard"


### PR DESCRIPTION
An existing change was bundled into the python-black linting commit which meant it wasn't spotted in review.

https://github.com/ThreeSixtyGiving/datagetter/commit/9222d58837c481be4a7b8b96fec20cc59f3ec924#diff-7920b1f56e648a409f837252432e39d050fa2aa9ade9e14896b2c5d826ea5361R310