### PR TITLE
get: Add read timeout

### DIFF
--- a/getter/get.py
+++ b/getter/get.py
@@ -208,6 +208,7 @@ def fetch_and_convert(args, dataset, schema_path, schema_package_path):
                 headers={
                     "User-Agent": "datagetter (https://github.com/ThreeSixtyGiving/datagetter)"
                 },
+                timeout=(30, 120),
             )
             res.raise_for_status()
 


### PR DESCRIPTION
By default, if the underlying connection succeeds, requests will wait forever for the web server to respond with content. This can cause the datagetter to hang in cases where web servers are misconfigured.

At time of writing, one of the publishers' web servers is hanging after sending the HTTP response header, but never sends any content. This is causing the datagetter to hang forever waiting for it to reply: https://www.berkeleyfoundation.org.uk/-/media/foundation/who-we-support/berkeley-foundation-grants-to-31-december-2024-updated-feb-25.ashx?rev=5992072954d644f2ba67876905153142&hash=9AA8345BE68A99DF77B1FD45D9F44DB

This PR adds a 30 second timeout to wait for the TLS/TCP connection to be established, and a 120 second timeout to wait (between sent bytes) for content.